### PR TITLE
Exclude bower_components, node_modules from git versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ GoogleService-Info.plist
 npm-debug.log
 public/libs
 public/scripts-es5
+bower_components/**
+node_modules/**
+.firebaserc
+firebase-debug.log


### PR DESCRIPTION
Add folders and files to gitignore to make easier to run the project without adding a bunch of files in git