### PR TITLE
Adding an account deletion link 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -116,6 +116,7 @@
           <li class="mdl-menu__item"><i class="material-icons">perm_contact_calendar</i> About - Help - Contact</li>
         </a>
         <li class="fp-sign-out mdl-menu__item fp-signed-in-only"><i class="material-icons">exit_to_app</i> Sign out</li>
+        <li class="fp-delete-account mdl-menu__item fp-signed-in-only"><i class="material-icons">cancel</i> Delete account</li>
       </ul>
     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -151,7 +151,8 @@
       <hr />
       <a class="mdl-navigation__link" href="/about"><i class="material-icons">perm_contact_calendar</i> About - Help - Contact</a>
       <hr class="fp-signed-in-only"/>
-      <a class="fp-sign-out mdl-navigation__link fp-signed-in-only"><i class="material-icons">exit_to_app</i> Sign Out</a>
+      <a class="fp-sign-out mdl-navigation__link fp-signed-in-only"><i class="material-icons">exit_to_app</i> Sign out</a>
+      <a class="fp-delete-account mdl-navigation__link fp-signed-in-only"><i class="material-icons">cancel</i> Delete account</a>
     </nav>
   </div>
 

--- a/public/scripts/auth.js
+++ b/public/scripts/auth.js
@@ -47,12 +47,14 @@ friendlyPix.Auth = class {
       this.signedInUserAvatar = $('.fp-avatar', signedInUserContainer);
       this.signedInUsername = $('.fp-username', signedInUserContainer);
       this.signOutButton = $('.fp-sign-out');
+      this.deleteAccountButton = $('.fp-delete-account');
       this.signedOutOnlyElements = $('.fp-signed-out-only');
       this.signedInOnlyElements = $('.fp-signed-in-only');
       this.usernameLink = $('.fp-usernamelink');
 
       // Event bindings
       this.signOutButton.click(() => this.auth.signOut());
+      this.deleteAccountButton.click(() => this.deleteAccount());
       this.signedInOnlyElements.hide();
     });
 
@@ -87,6 +89,19 @@ friendlyPix.Auth = class {
       }
     });
   }
+
+  deleteAccount() {
+    this.auth.currentUser.delete().then(function() {
+      window.alert('Account deleted');
+    }).catch(function(error) {
+      if (error.code === 'auth/requires-recent-login') {
+        window.alert(
+          'You need to have recently signed-in to delete your account.\n' +
+            'Please sign-in and try again.');
+        this.auth.signOut();
+      }
+    });
+  };
 };
 
 friendlyPix.auth = new friendlyPix.Auth();

--- a/public/scripts/auth.js
+++ b/public/scripts/auth.js
@@ -91,9 +91,9 @@ friendlyPix.Auth = class {
   }
 
   deleteAccount() {
-    this.auth.currentUser.delete().then(function() {
+    this.auth.currentUser.delete().then(() => {
       window.alert('Account deleted');
-    }).catch(function(error) {
+    }).catch(error => {
       if (error.code === 'auth/requires-recent-login') {
         window.alert(
           'You need to have recently signed-in to delete your account.\n' +


### PR DESCRIPTION
This PR adds and wires up a `Delete account` link next to the `Sign out` button. I added this for a demo of wiping out user data on an `Auth.delete()` call, but I'm sending this change back so more demo apps can start making use of account deletion generally. 

Feel free to either post comments of things you'd like changed or to change things yourself if it's easier.

Here's a Friendly Pix screenshot with the new link, gratuitously including a pic of my cat, @liskovcat:

<img width="591" alt="screen shot 2017-11-10 at 12 05 27 pm" src="https://user-images.githubusercontent.com/209641/32676570-f80a4e4a-c60f-11e7-8361-ef95306a7664.png">