### PR TITLE
Added cloud functions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Then open [http://localhost:5000](http://localhost:5000)
 > Note 2: Cloud Functions cannot yet be ran locally. Deploy the app once first to deploy and enable the Cloud Functions.
 
 
+## Cloud Functions
+
+The required Cloud Functions can be found at [/functions](https://github.com/firebase/friendlypix-web/tree/master/functions).
+
+
 ## Deploy the app
 
 Before deploying your code you need to build it for production. Run:


### PR DESCRIPTION
There is no documentation pointing to the required Cloud Functions at all.

Developers trying to run mobile examples only (android and/or iOS) won't be able to make it work as expected.

Also, even on this repository, there is no instruction regarding publishing the functions (nor publishing the functions only).

This PR adds a link to the Cloud Functions into the README.